### PR TITLE
Remove socket extension dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ PHP client of [Sonic search](https://github.com/valeriansaliou/sonic)
 ## Requirements
 
 - PHP >= 7.0
-- [Sockets extension](https://www.php.net/manual/en/book.sockets.php)
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "keywords": ["sonic", "search"],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,11 @@
     "name": "php-sonic/php-sonic",
     "type": "library",
     "description": "PHP client of Sonic search",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": "MIT",
     "keywords": ["sonic", "search"],
     "require": {
         "php": "^7.0",
-        "ext-sockets": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since we are using the Stream-API now, we should no longer need the PHP socket extension.