### PR TITLE
replace join() with implode() to get this working with PHP 7.4

### DIFF
--- a/src/SonicMessage.php
+++ b/src/SonicMessage.php
@@ -21,7 +21,7 @@ class SonicMessage
 
     public function serialize(): string
     {
-        return join($this->segments, ' ');
+        return implode(' ', $this->segments);
     }
 
     public function getVerb(): string


### PR DESCRIPTION
PHP 7.4 changed the order of $glue and $pieces for join. it's the same order for implode in older PHP versions though, so I updated the code to use implode.

[Changelog implode](https://www.php.net/manual/en/function.implode.php)