### PR TITLE
Fix IngestChannel's pop call

### DIFF
--- a/src/ControlChannel.php
+++ b/src/ControlChannel.php
@@ -14,7 +14,7 @@ class ControlChannel extends Channel
 
     /**
      * Trigger the given action.
-     * @param action string The action to triger.
+     * @param $action string The action to trigger.
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      */

--- a/src/IngestChannel.php
+++ b/src/IngestChannel.php
@@ -2,6 +2,8 @@
 
 namespace SonicSearch;
 
+use InvalidArgumentException;
+
 /**
  * Sonic session implementation for Sonic's ingest mode.
  */
@@ -14,9 +16,10 @@ class IngestChannel extends Channel
 
     /**
      * Push the given terms into Sonic's index at the given "path" (collection, bucket, object).
-     * @param collection string Collection within Sonic to push the given terms into.
-     * @param bucket string Optional bucket within the collection to push the given terms into.
-     * @param object string Optional object within the given bucket to push the given terms into.
+     * @param $collection string Collection within Sonic to push the given terms into.
+     * @param $bucket string Bucket within the collection to push the given terms into.
+     * @param $object string Object within the given bucket to push the given terms into.
+     * @param $terms string The terms to push into the object.
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      * @throws InvalidArgumentException If the given set of terms could not fit into Sonics receive buffer.
@@ -37,9 +40,11 @@ class IngestChannel extends Channel
 
     /**
      * Pop-Search the given terms from Sonic's index with the given "path" (collection, bucket, object).
-     * @param collection string Collection within Sonic to pop-search the given terms from.
-     * @param bucket string Optional bucket within the collection to pop-search the given terms from.
-     * @param object string Optional object within the given bucket to pop-search the given terms from.
+     * @param $collection string Collection within Sonic to pop-search the given terms from.
+     * @param $bucket string Bucket within the collection to pop-search the given terms from.
+     * @param $object string Object within the given bucket to pop-search the given terms from.
+     * @param $terms string The terms to pop-search.
+     * @return int
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      * @throws InvalidArgumentException If the given set of terms could not fit into Sonics receive buffer.
@@ -63,9 +68,10 @@ class IngestChannel extends Channel
 
     /**
      * Count the amount of terms within the given "path" (collection, [bucket, [object]]) in Sonic's index.
-     * @param collection string Collection within Sonic to count terms in.
-     * @param bucket string Optional bucket within the collection to count terms in.
-     * @param object string Optional object within the given bucket to count terms in.
+     * @param $collection string Collection within Sonic to count terms in.
+     * @param $bucket string Optional bucket within the collection to count terms in.
+     * @param $object string Optional object within the given bucket to count terms in.
+     * @return int
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      */
@@ -87,9 +93,10 @@ class IngestChannel extends Channel
 
     /**
      * Flush the given "path" (collection, [bucket, [object]]) in Sonic's index.
-     * @param collection string Collection within Sonic to flush.
-     * @param bucket string Optional bucket within the collection to flush.
-     * @param object string Optional object within the given bucket to flush.
+     * @param $collection string Collection within Sonic to flush.
+     * @param $bucket string Optional bucket within the collection to flush.
+     * @param $object string Optional object within the given bucket to flush.
+     * @return int
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      */

--- a/src/IngestChannel.php
+++ b/src/IngestChannel.php
@@ -57,7 +57,7 @@ class IngestChannel extends Channel
         foreach ($valueSplits as $valueChunk) {
             $popChunkMessage = $popMessageTemplate;
             $popChunkMessage->setArgument(3, SonicMessage::quoted($valueChunk));
-            $response = $this->sendMessage($popChunkMessage);
+            $response = $this->sendAndAwaitResponse($popChunkMessage);
             if ($response->getVerb() != 'RESULT') {
                 throw new CommandFailedException($popChunkMessage, $response);
             }

--- a/src/SearchChannel.php
+++ b/src/SearchChannel.php
@@ -14,11 +14,12 @@ class SearchChannel extends Channel
 
     /**
      * Query Sonic for the given search terms.
-     * @param collection string Collection within Sonic to query for the given search-term.
-     * @param bucket string Bucket within the collection to query for the given search-term.
-     * @param terms string A search string containing multiple words to query the given bucket for.
-     * @param limit int Optional limit to the amount of returned search results.
-     * @param offset int Optional offset in the pagination of search-results introduced by the limit.
+     * @param $collection string Collection within Sonic to query for the given search-term.
+     * @param $bucket string Bucket within the collection to query for the given search-term.
+     * @param $terms string A search string containing multiple words to query the given bucket for.
+     * @param $limit int Optional limit to the amount of returned search results.
+     * @param $offset int Optional offset in the pagination of search-results introduced by the limit.
+     * @return array
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      */
@@ -47,10 +48,10 @@ class SearchChannel extends Channel
 
     /**
      * Request word suggestion from sonic, for the given string.
-     * @param collection string Collection within Sonic to search for suggestions in.
-     * @param bucket string Bucket within the collection to search for suggestions in.
-     * @param word Beginning of the word to request completions for.
-     * @param limit int Optional limit to the amount of returned suggestions.
+     * @param $collection string Collection within Sonic to search for suggestions in.
+     * @param $bucket string Bucket within the collection to search for suggestions in.
+     * @param $word string Beginning of the word to request completions for.
+     * @param $limit int Optional limit to the amount of returned suggestions.
      * @throws NoConnectionException If the connection to Sonic has been lost in the meantime.
      * @throws CommandFailedException If execution of the command failed for which-ever reason.
      */

--- a/src/SonicArgumentList.php
+++ b/src/SonicArgumentList.php
@@ -16,8 +16,8 @@ class SonicArgumentList
 
     /**
      * Parse the given message segment array, starting at a given index as argument list.
-     * @param message string[] Array of message segments to parse as argument list.
-     * @param startIdx int Index at which to start parsing within the given message segment list.
+     * @param $message string[] Array of message segments to parse as argument list.
+     * @param $startIdx int Index at which to start parsing within the given message segment list.
      * @return SonicArgumentList Parsed argument list.
      */
     public static function fromMessage(array &$message, int $startIdx): SonicArgumentList


### PR DESCRIPTION
The `pop` method on the IngestChannel was calling `sendMessage` instead of `sendAndAwaitResponse`, but still expecting a returned response to use further down the function.

I've also fixed up some doc blocks at the same time.